### PR TITLE
fix: streaming /api/streams 응답 streamKey 누락 수정

### DIFF
--- a/docs/interfaces/streaming-api.md
+++ b/docs/interfaces/streaming-api.md
@@ -70,7 +70,7 @@ streaming이 자동 생성·서빙. 브라우저는 web-backend가 알려준 상
 
 | Endpoint | Method | 응답 |
 |----------|--------|------|
-| `/api/streams` | GET | 활성 스트림 목록: `[{cameraId, hlsUrl, active, startedAt}]` |
+| `/api/streams` | GET | 활성 스트림 목록: `[{cameraId, streamKey, hlsUrl, active, startedAt}]` |
 | `/healthz` | GET | 헬스체크 (200 OK) |
 
 ### `/api/streams` 응답 예시
@@ -79,6 +79,7 @@ streaming이 자동 생성·서빙. 브라우저는 web-backend가 알려준 상
 [
   {
     "cameraId": "cam-001",
+    "streamKey": "cam-001",
     "hlsUrl": "/live/cam-001/index.m3u8",
     "active": true,
     "startedAt": "2026-04-13T09:00:00Z"
@@ -86,7 +87,7 @@ streaming이 자동 생성·서빙. 브라우저는 web-backend가 알려준 상
 ]
 ```
 
-> `cameraId`는 RTMP 발행 시 사용한 `streamKey`와 동일합니다 (URL의 `{streamKey}`).
+> `streamKey`는 RTMP 발행 시 URL의 `{streamKey}` 값이며, `cameraId`와 동일합니다.
 
 web-backend는 이 API만 호출하면 스트림 상태/URL을 알 수 있습니다.
 

--- a/services/streaming/main.go
+++ b/services/streaming/main.go
@@ -23,6 +23,7 @@ var streamActiveTimeout = func() time.Duration {
 
 type StreamInfo struct {
 	CameraID  string `json:"cameraId"`
+	StreamKey string `json:"streamKey"`
 	HlsURL    string `json:"hlsUrl"`
 	Active    bool   `json:"active"`
 	StartedAt string `json:"startedAt"`
@@ -74,6 +75,7 @@ func handleStreams(w http.ResponseWriter, r *http.Request) {
 
 		streams = append(streams, StreamInfo{
 			CameraID:  cameraID,
+			StreamKey: cameraID,
 			HlsURL:    "/live/" + cameraID + "/index.m3u8",
 			Active:    active,
 			StartedAt: info.ModTime().UTC().Format(time.RFC3339),

--- a/services/streaming/main.go
+++ b/services/streaming/main.go
@@ -73,6 +73,11 @@ func handleStreams(w http.ResponseWriter, r *http.Request) {
 		// Consider stream active if playlist was modified within the detection window
 		active := time.Since(info.ModTime()) < streamActiveTimeout
 
+		// cameraID is the HLS subdirectory name, which equals the RTMP stream key
+		// (i.e. the value nginx-rtmp receives as the URL path segment after /live/).
+		// The adapter pushes to rtmp://streaming:1935/live/{streamKey}, where
+		// streamKey == cameras.stream_key in the DB (format: "cam-{8hex}").
+		// nginx-rtmp writes segments to /tmp/hls/{streamKey}/, so cameraID == streamKey.
 		streams = append(streams, StreamInfo{
 			CameraID:  cameraID,
 			StreamKey: cameraID,

--- a/services/web-backend/cameras.go
+++ b/services/web-backend/cameras.go
@@ -58,6 +58,7 @@ type streamCache struct {
 
 type streamInfo struct {
 	CameraID  string `json:"cameraId"`
+	StreamKey string `json:"streamKey"`
 	HLSUrl    string `json:"hlsUrl"`
 	Active    bool   `json:"active"`
 	StartedAt string `json:"startedAt"`


### PR DESCRIPTION
docs/services/streaming.md 명세에 있는 streamKey 필드가 실제 응답에 빠져 있던 문제 수정