### PR TITLE
fix: notifier toggle + contacts auth 분리 + WAL checkpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,31 @@
+# Sentinel — Environment Variables Example
+# Copy to .env and fill in values as needed.
+
+# Frontend URL (used in CCTV temp links sent via notifications)
+FRONTEND_URL=http://localhost:3080
+
+# Notifier - Kakao 알림톡
+# Set KAKAO_ENABLED=true to activate. All keys must be set for delivery.
+KAKAO_ENABLED=false
+KAKAO_API_URL=
+KAKAO_API_KEY=
+KAKAO_SENDER_KEY=
+KAKAO_TEMPLATE_CODE=CRISIS_ALERT
+
+# Notifier - SMS (NHN Cloud)
+# Set SMS_ENABLED=true to activate. All keys must be set for delivery.
+SMS_ENABLED=false
+NHN_SMS_APP_KEY=
+NHN_SMS_SECRET_KEY=
+NHN_SMS_SENDER_NO=
+
+# Notifier - Email (SMTP)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_FROM=
+
+# Admin credentials (used for initial seed)
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=sentinel1234

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,10 +98,12 @@ services:
       - WEB_BACKEND_URL=http://web-backend:8080
       - FRONTEND_URL=${FRONTEND_URL:-http://localhost:3080}
       - RECORDING_URL=http://recording:8080
+      - KAKAO_ENABLED=${KAKAO_ENABLED:-false}
       - KAKAO_API_URL=${KAKAO_API_URL:-}
       - KAKAO_API_KEY=${KAKAO_API_KEY:-}
       - KAKAO_SENDER_KEY=${KAKAO_SENDER_KEY:-}
       - KAKAO_TEMPLATE_CODE=${KAKAO_TEMPLATE_CODE:-CRISIS_ALERT}
+      - SMS_ENABLED=${SMS_ENABLED:-false}
       - NHN_SMS_APP_KEY=${NHN_SMS_APP_KEY:-}
       - NHN_SMS_SECRET_KEY=${NHN_SMS_SECRET_KEY:-}
       - NHN_SMS_SENDER_NO=${NHN_SMS_SENDER_NO:-}

--- a/services/notifier/main.go
+++ b/services/notifier/main.go
@@ -176,7 +176,7 @@ func fetchSiteURL(cfg Config) string {
 // --- Contact/Link Fetching ---
 
 func fetchContacts(cfg Config) ([]Contact, error) {
-	resp, err := httpClient.Get(cfg.WebBackendURL + "/api/contacts")
+	resp, err := httpClient.Get(cfg.WebBackendURL + "/internal/contacts")
 	if err != nil {
 		return nil, fmt.Errorf("fetch contacts: %w", err)
 	}
@@ -517,6 +517,15 @@ func dispatchNotifications(cfg Config, alert AlertPayload) (int, []NotifyResult)
 
 	// 3. Send to all contacts in parallel with fallback chain: KakaoTalk → SMS → Web alarm
 	//    Email is an independent channel — sent in parallel for contacts with notifyEmail=true
+	kakaoEnabled := os.Getenv("KAKAO_ENABLED") == "true"
+	smsEnabled := os.Getenv("SMS_ENABLED") == "true"
+	if !kakaoEnabled {
+		log.Printf("[notify] KakaoTalk disabled (KAKAO_ENABLED=false), skipping Kakao channel")
+	}
+	if !smsEnabled {
+		log.Printf("[notify] SMS disabled (SMS_ENABLED=false), skipping SMS channel")
+	}
+
 	var wg sync.WaitGroup
 	results := make([]NotifyResult, len(contacts))
 
@@ -543,29 +552,39 @@ func dispatchNotifications(cfg Config, alert AlertPayload) (int, []NotifyResult)
 				ContactName: c.Name,
 			}
 
-			// Step 1: Try KakaoTalk
-			kakaoErr := sendKakaoTalk(cfg, c, alert, cctvLink)
-			if kakaoErr == nil {
-				result.Channel = "kakaotalk"
-				result.Success = true
-				log.Printf("[notify] KakaoTalk SUCCESS for %s (%s)", c.Name, c.Phone)
-				results[idx] = result
-				return
+			// Step 1: Try KakaoTalk (if enabled)
+			var kakaoErr error
+			if !kakaoEnabled {
+				kakaoErr = fmt.Errorf("KakaoTalk disabled (KAKAO_ENABLED=false)")
+			} else {
+				kakaoErr = sendKakaoTalk(cfg, c, alert, cctvLink)
+				if kakaoErr == nil {
+					result.Channel = "kakaotalk"
+					result.Success = true
+					log.Printf("[notify] KakaoTalk SUCCESS for %s (%s)", c.Name, c.Phone)
+					results[idx] = result
+					return
+				}
+				log.Printf("[notify] KakaoTalk FAILED for %s (%s): %v — falling back to SMS", c.Name, c.Phone, kakaoErr)
 			}
-			log.Printf("[notify] KakaoTalk FAILED for %s (%s): %v — falling back to SMS", c.Name, c.Phone, kakaoErr)
 
-			// Step 2: Fallback to SMS
-			smsErr := sendSMS(cfg, c, alert, cctvLink)
-			if smsErr == nil {
-				result.Channel = "sms"
-				result.Success = true
-				log.Printf("[notify] SMS SUCCESS for %s (%s)", c.Name, c.Phone)
-				results[idx] = result
-				return
+			// Step 2: Fallback to SMS (if enabled)
+			var smsErr error
+			if !smsEnabled {
+				smsErr = fmt.Errorf("SMS disabled (SMS_ENABLED=false)")
+			} else {
+				smsErr = sendSMS(cfg, c, alert, cctvLink)
+				if smsErr == nil {
+					result.Channel = "sms"
+					result.Success = true
+					log.Printf("[notify] SMS SUCCESS for %s (%s)", c.Name, c.Phone)
+					results[idx] = result
+					return
+				}
+				log.Printf("[notify] SMS FAILED for %s (%s): %v — sending system alarm", c.Name, c.Phone, smsErr)
 			}
-			log.Printf("[notify] SMS FAILED for %s (%s): %v — sending system alarm", c.Name, c.Phone, smsErr)
 
-			// Step 3: Both failed — send system alarm to web-backend
+			// Step 3: Both channels unavailable or failed — send system alarm to web-backend
 			sendSystemAlarm(cfg, c, alert, kakaoErr, smsErr)
 			result.Channel = "alarm"
 			result.Success = false

--- a/services/web-backend/main.go
+++ b/services/web-backend/main.go
@@ -68,7 +68,7 @@ func main() {
 	mux.HandleFunc("/ws", handleWebSocket())
 
 	// Internal service routes (no auth — accessed by other services via Docker network)
-	mux.HandleFunc("GET /api/contacts", handleListContacts(db))
+	mux.HandleFunc("GET /internal/contacts", handleListContacts(db))
 	mux.HandleFunc("POST /api/links/temp", handleCreateTempLink(db))
 	mux.HandleFunc("GET /api/links/verify/{token}", handleVerifyTempLink())
 
@@ -195,6 +195,7 @@ func initDB(path string) (*sql.DB, error) {
 		"PRAGMA journal_mode=WAL",
 		"PRAGMA busy_timeout=5000",
 		"PRAGMA foreign_keys=ON",
+		"PRAGMA wal_autocheckpoint=100",
 	}
 	for _, p := range pragmas {
 		if _, err := db.ExecContext(ctx, p); err != nil {


### PR DESCRIPTION
## 변경 사항

### Issue #4 — Notifier 채널 toggle
- `KAKAO_ENABLED`, `SMS_ENABLED` 환경변수 추가 (기본값 `false`)
- 비활성화 시 해당 채널을 건너뛰고 로그 출력 (`skipping Kakao/SMS channel`)
- 기존 fallback 구조(Kakao → SMS → System alarm) 유지
- `docker-compose.yml`에 기본값 `false`로 설정
- `.env.example` 추가 (Kakao, SMS, SMTP 키 목록 문서화)

### Issue #6 — contacts 인증 분리
- `GET /api/contacts` public mux 노출 제거
- `GET /internal/contacts` Docker 내부망 전용 경로 추가
- notifier의 `fetchContacts` URL을 `/internal/contacts`로 변경

### Issue #7 — WAL 자동 체크포인트
- DB 초기화 PRAGMA 목록에 `PRAGMA wal_autocheckpoint=100` 추가
- WAL 파일이 100페이지(약 400KB) 누적 시 자동 체크포인트 수행

## 빌드 확인
- `docker compose build notifier web-backend` 성공

Closes #4
Closes #6
Closes #7